### PR TITLE
Improve mobile performance: faster LCP and lighter critical path

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -60,6 +60,13 @@ h1, h2, h3, h4, h5, h6 {
   color: var(--color-ink);
 }
 
+/* Skip layout/paint work for below-the-fold sections until the user nears
+   them — improves Speed Index and main-thread time on mobile. */
+.cv-auto {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 700px;
+}
+
 /* Accent hover for links on light surfaces */
 .hover-accent {
   transition: color 0.2s ease;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,26 +4,28 @@ import "./globals.css";
 import { Inter, Space_Grotesk, JetBrains_Mono } from 'next/font/google';
 import { SITE_URL, SITE_NAME, SITE_DESCRIPTION, SOCIAL_LINKS, SOCIAL_IMAGE } from "@/lib/site";
 
-// Define fonts with next/font
+// Define fonts with next/font. Only ship the weights actually used on the
+// site — the hero heading is the LCP element, so every extra font byte
+// delays the swap that finalizes LCP on mobile.
 const inter = Inter({
   subsets: ['latin'],
   display: 'swap',
   variable: '--font-inter',
-  weight: ['400', '500', '600'],
+  weight: ['400', '500'],
 });
 
 const spaceGrotesk = Space_Grotesk({
   subsets: ['latin'],
   display: 'swap',
   variable: '--font-space-grotesk',
-  weight: ['500', '600', '700'],
+  weight: ['500', '700'],
 });
 
 const jetbrainsMono = JetBrains_Mono({
   subsets: ['latin'],
   display: 'swap',
   variable: '--font-jetbrains-mono',
-  weight: ['400', '500', '700'],
+  weight: ['400'],
 });
 
 export const metadata: Metadata = {
@@ -138,7 +140,7 @@ export default function RootLayout({
           dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
         />
         {children}
-        <Script id="ms-clarity" strategy="afterInteractive">
+        <Script id="ms-clarity" strategy="lazyOnload">
           {`
             (function(c,l,a,r,i,t,y){
               c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -142,7 +142,7 @@ const ICChip = ({ className = '' }: { className?: string }) => (
 
 const Footer = () => {
   return (
-    <footer className="mt-auto py-6 relative overflow-hidden" style={{ backgroundColor: '#151238', color: '#ECEAF8' }}>
+    <footer className="mt-auto py-6 relative overflow-hidden cv-auto" style={{ backgroundColor: '#151238', color: '#ECEAF8' }}>
       {/* Circuit Board Background - deep indigo PCB */}
       <div className="absolute inset-0 z-0" style={{ backgroundColor: '#1B1745', opacity: 0.7 }}>
         {/* Background grid pattern */}

--- a/components/sections/About.tsx
+++ b/components/sections/About.tsx
@@ -51,7 +51,7 @@ const ImageGallery = () => {
 
 const About = () => {
   return (
-    <section id="about" className="py-16 bg-white/60">
+    <section id="about" className="py-16 bg-white/60 cv-auto">
       <div className="container mx-auto px-4 max-w-6xl">
         <h2 className="text-3xl font-heading tracking-widest mb-12 text-center uppercase text-ink">
           About Us

--- a/components/sections/EventsTimeline.tsx
+++ b/components/sections/EventsTimeline.tsx
@@ -69,7 +69,7 @@ const EventCard = ({ event }: { event: Event }) => {
 
 const EventsTimeline = () => {
   return (
-    <section id="events" className="py-16">
+    <section id="events" className="py-16 cv-auto">
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-heading tracking-widest mb-12 text-center uppercase text-ink">
           Schedule

--- a/components/sections/Resources.tsx
+++ b/components/sections/Resources.tsx
@@ -47,7 +47,7 @@ const ResourceCard = ({ title, description, buttonText, buttonLink, color, icon,
 
 const Resources = () => {
   return (
-    <section id="resources" className="py-16 bg-white/60">
+    <section id="resources" className="py-16 bg-white/60 cv-auto">
 
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-heading tracking-widest mb-12 text-center uppercase text-ink">

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  experimental: {
+    // Inline CSS into the HTML instead of render-blocking <link> stylesheets —
+    // removes a critical-path round trip that delays first render on mobile.
+    inlineCss: true,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

Targets the mobile PageSpeed score (74), where the failing metric is **LCP** — the LCP element is the hero heading, whose paint finalizes only after the Space Grotesk web font swaps in over throttled 4G.

- **Trim unused font weights** — dropped Inter 600, Space Grotesk 600, and JetBrains Mono 500/700 (verified unused across the site). Total font payload: 101KB → 88KB; the LCP-critical heading font file: 31KB → 20KB.
- **Inline CSS** (`experimental.inlineCss`) — first render no longer waits on two render-blocking stylesheet round trips.
- **Clarity → `lazyOnload`** — the analytics tag loads after everything else instead of competing with the critical window.
- **`content-visibility: auto`** on below-the-fold sections (About, Events, Resources, Footer) — skips offscreen layout/paint during load to help Speed Index. Deliberately not applied to the Team section, which measures its scroll width on mount.

## Verification
- `npm run build` passes; all routes render and return 200.
- Homepage HTML confirmed: zero `<link rel="stylesheet">` (CSS inlined into a `<style>` tag), reduced font preloads.
- Lighthouse before/after under identical conditions: FCP 1.1s → 0.9s, LCP 2.7s → 2.4s, render-blocking audit now passes.
- Screenshot-verified typography is unchanged (all in-use weights — Inter 400/500, Space Grotesk 500/700, Mono 400 — kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S81UkGSc8Tok7Aqnim9Lyn

---
_Generated by [Claude Code](https://claude.ai/code/session_01S81UkGSc8Tok7Aqnim9Lyn)_