### PR TITLE
Add Lenis smooth scrolling, brand scroll-to-top, IG link + AI Inference Server project

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Script from "next/script";
 import "./globals.css";
+import SmoothScroll from "@/components/SmoothScroll";
 import { Inter, Space_Grotesk, JetBrains_Mono } from 'next/font/google';
 import { SITE_URL, SITE_NAME, SITE_DESCRIPTION, SOCIAL_LINKS, SOCIAL_IMAGE } from "@/lib/site";
 
@@ -139,6 +140,7 @@ export default function RootLayout({
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
         />
+        <SmoothScroll />
         {children}
         <Script id="ms-clarity" strategy="lazyOnload">
           {`

--- a/components/SmoothScroll.tsx
+++ b/components/SmoothScroll.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+import Lenis from 'lenis';
+import 'lenis/dist/lenis.css';
+import { setLenis, getLenis } from '@/lib/lenis';
+
+// Site-wide Lenis smooth scrolling. Renders nothing; mounted once in the
+// root layout. Skipped entirely for users who prefer reduced motion.
+const SmoothScroll = () => {
+  useEffect(() => {
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    const lenis = new Lenis({ autoRaf: true, anchors: true });
+    setLenis(lenis);
+
+    return () => {
+      lenis.destroy();
+      setLenis(null);
+    };
+  }, []);
+
+  // On route change, cancel any in-flight scroll animation (stop/start resets
+  // Lenis to the browser's actual position) so leftover momentum can't fight
+  // the new page's scroll placement — top on navigation, anchor target on
+  // hash links, or the restored position on back/forward.
+  const pathname = usePathname();
+  useEffect(() => {
+    const lenis = getLenis();
+    lenis?.stop();
+    lenis?.start();
+  }, [pathname]);
+
+  return null;
+};
+
+export default SmoothScroll;

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -221,7 +221,7 @@ const Footer = () => {
             <div>
               <div className="text-xs font-mono mb-1 border-b border-[#6C63D2]/30 pb-0.5" style={{ color: '#ECEAF8' }}>Social</div>
               <NetworkLink href="https://www.linkedin.com/company/data-science-club-wmu/" label="LinkedIn" color="blue" />
-              <NetworkLink href="https://www.instagram.com/wmudatascience" label="Instagram" color="pink" />
+              <NetworkLink href="https://www.instagram.com/dsaicwmu/" label="Instagram" color="pink" />
               <NetworkLink href="https://experiencewmu.wmich.edu/organization/dsaic" label="ExperienceWMU" color="gold" />
             </div>
 

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -3,18 +3,35 @@
 import React, { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { getLenis } from '@/lib/lenis';
 
 const Header = () => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const pathname = usePathname();
 
   const toggleMobileMenu = () => {
     setMobileMenuOpen(!mobileMenuOpen);
   };
 
+  // On the homepage, clicking the brand scrolls back to the top instead of
+  // re-navigating; from other pages it acts as a normal link home.
+  const handleBrandClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    if (pathname !== '/') return;
+    event.preventDefault();
+    const lenis = getLenis();
+    if (lenis) {
+      lenis.scrollTo(0);
+    } else {
+      // No Lenis means the user prefers reduced motion — jump instantly.
+      window.scrollTo({ top: 0 });
+    }
+  };
+
   return (
     <header className="sticky top-0 z-50 w-full py-3 isolate">
       <div className="container mx-auto rounded-full bg-white/70 backdrop-filter backdrop-blur-md border border-lavender shadow-[0_4px_16px_rgba(37,25,122,0.08)] hover:shadow-[0_4px_20px_rgba(37,25,122,0.12)] transition-all px-6 py-2.5 flex justify-between items-center">
-        <Link href="/" className="flex items-center gap-3 hover:opacity-80 transition-opacity">
+        <Link href="/" onClick={handleBrandClick} className="flex items-center gap-3 hover:opacity-80 transition-opacity">
           <div className="relative w-10 h-10">
             <Image
               src="/dsaic-logo.png"

--- a/components/sections/Projects.tsx
+++ b/components/sections/Projects.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import ProjectCard from '../cards/ProjectCard';
 import Link from 'next/link';
-import { FaCoins, FaCarSide } from 'react-icons/fa';
+import { FaCoins, FaCarSide, FaServer } from 'react-icons/fa';
 
-// 2026-27 active projects, both eboard-led
+// 2026-27 active projects, all eboard-led
 const projects = [
+  {
+    name: "AI Inference Server",
+    lead: "Cody",
+    icon: <FaServer />,
+    description: "A club-owned dual-GPU server for running open models like Gemma 4 locally, exposed to members as a shared API endpoint. Infrastructure for our agentic projects and a hands-on look at what it takes to self-host serious AI on a budget.",
+  },
   {
     name: "Club Finance AI",
     lead: "Rafia",

--- a/lib/lenis.ts
+++ b/lib/lenis.ts
@@ -1,0 +1,14 @@
+import type Lenis from 'lenis';
+
+// Shared handle to the active Lenis instance, set by <SmoothScroll /> on
+// mount. Null when smooth scrolling is inactive (SSR, reduced motion), so
+// consumers must fall back to native scrolling.
+let instance: Lenis | null = null;
+
+export function setLenis(lenis: Lenis | null) {
+  instance = lenis;
+}
+
+export function getLenis(): Lenis | null {
+  return instance;
+}

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -17,7 +17,7 @@ export const SITE_DESCRIPTION =
 // via schema.org `sameAs`.
 export const SOCIAL_LINKS = [
   'https://www.linkedin.com/company/data-science-club-wmu/',
-  'https://www.instagram.com/wmudatascience',
+  'https://www.instagram.com/dsaicwmu/',
   'https://experiencewmu.wmich.edu/organization/dsaic',
   'https://github.com/Data-Science-Club-at-WMU',
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "dsc-website",
       "version": "0.1.0",
       "dependencies": {
+        "lenis": "^1.3.25",
         "next": "15.5.20",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -4270,6 +4271,37 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/lenis": {
+      "version": "1.3.25",
+      "resolved": "https://registry.npmjs.org/lenis/-/lenis-1.3.25.tgz",
+      "integrity": "sha512-mOKxayErlaONK8fm4LN3XNd99Qu4plTpn9h9qf8wxzjGrJDzuD84FYzZ81HCd6ZsWp++VWVwOzL286Pf2s2u4A==",
+      "license": "MIT",
+      "workspaces": [
+        "packages/*",
+        "playground",
+        "playground/*"
+      ],
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/darkroomengineering"
+      },
+      "peerDependencies": {
+        "@nuxt/kit": ">=3.0.0",
+        "react": ">=17.0.0",
+        "vue": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@nuxt/kit": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
       }
     },
     "node_modules/levn": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "lenis": "^1.3.25",
     "next": "15.5.20",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",


### PR DESCRIPTION
## Summary
- **Lenis smooth scrolling site-wide**: new `SmoothScroll` client component mounted in the root layout drives window scroll through [Lenis](https://lenis.darkroom.engineering) (v1.3.25, `autoRaf` + `anchors`). It skips initialization for `prefers-reduced-motion` users and cancels in-flight scroll animations on route changes so leftover momentum can't fight the new page's scroll position. The active instance is shared via `lib/lenis.ts`.
- **Brand scroll-to-top**: clicking the logo/club name in the nav on the homepage now smooth-scrolls back to the top (Lenis-eased, instant jump for reduced-motion users); from other pages it still navigates home normally.
- **Footer Instagram link** updated to `https://www.instagram.com/dsaicwmu/` (footer + schema.org `sameAs` in `lib/site.ts`).
- **AI Inference Server** added as the first card on the Projects page (Lead: Cody, server icon).

## Testing
- `npm run build` passes (all 11 static pages generate)
- Playwright end-to-end against the production build, all passing:
  - Lenis engages (`html.lenis` present) and wheel scrolling works
  - Brand click animates back to `scrollY=0` through intermediate frames without re-navigating
  - With `prefers-reduced-motion: reduce`, Lenis stays disabled
  - Footer Instagram href verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4kgQ8QvqNASGU5PmyUZhK