### PR TITLE
Expand schedule cards, 3-wide projects grid, and Info Night event link

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,16 @@ upload can't be accessed. Note that images returned by the Read tool are
 embedded in the transcript the same way — dedupe candidates by byte-comparing
 against existing files in the repo.
 
+## PR workflow — check merge state before reusing anything
+
+The user merges PRs fast, often minutes after they're opened. Before pushing
+follow-up commits to the session branch or touching an existing PR's
+title/body, re-fetch and check whether that PR already merged. Once merged:
+rebase any unmerged commits onto fresh `origin/main` (dropping the merged
+ones), force-with-lease push, and open a NEW PR — pushes to a merged PR's
+branch don't reopen it, and editing a merged PR's description corrupts the
+historical record of what it shipped.
+
 ## Site quick reference
 
 - The homepage "slideshow" is the About-section gallery: `GALLERY_IMAGES` in

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { FaExternalLinkAlt } from "react-icons/fa";
 import Header from "@/components/layout/Header";
 import Footer from "@/components/layout/Footer";
 
@@ -13,6 +14,7 @@ type Event = {
   date: string;
   description: string;
   color: "violet" | "ink";
+  link?: { href: string; label: string };
 };
 
 const events: Event[] = [
@@ -29,6 +31,7 @@ const events: Event[] = [
     date: "Thu Sep 3 2026, 6:30-9:00pm | Parkview Campus, Room D-109",
     description: "Kick off the year with us! Featuring speaker Jia Chen, plus introductions to Developer Club, DSAIC, and W1 Builders. Hosted in collaboration with Developer Club and W1 Builders.",
     color: "ink",
+    link: { href: "https://experiencewmu.wmich.edu/event/12515581", label: "Event Details" },
   },
   {
     id: 3,
@@ -107,6 +110,22 @@ const CalendarPage = () => {
                       {/* Description */}
                       <div className="p-4">
                         <p className="text-ink/75">{event.description}</p>
+                        {event.link && (
+                          <a
+                            href={event.link.href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="mt-3 inline-flex items-center gap-2 px-4 py-2 text-sm font-bold rounded-md border transition-opacity hover:opacity-75"
+                            style={{
+                              color: colorValue,
+                              borderColor: colorValueBorder,
+                              backgroundColor: colorValueTransparent,
+                            }}
+                          >
+                            {event.link.label}
+                            <FaExternalLinkAlt className="text-xs" aria-hidden />
+                          </a>
+                        )}
                       </div>
                     </div>
                   </div>

--- a/components/sections/EventsTimeline.tsx
+++ b/components/sections/EventsTimeline.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from 'react';
+import { FaExternalLinkAlt } from 'react-icons/fa';
 
 type Event = {
   id: number;
@@ -8,6 +9,7 @@ type Event = {
   date: string;
   description: string;
   color: 'violet' | 'ink';
+  link?: { href: string; label: string };
 };
 
 const events: Event[] = [
@@ -24,6 +26,7 @@ const events: Event[] = [
     date: "Thu Sep 3 2026, 6:30-9pm | Parkview D-109",
     description: "Kick off the year with us! Featuring speaker Jia Chen, plus introductions to Developer Club, DSAIC, and W1 Builders.",
     color: "ink",
+    link: { href: "https://experiencewmu.wmich.edu/event/12515581", label: "Event Details" },
   },
   {
     id: 3,
@@ -39,6 +42,9 @@ const EventCard = ({ event }: { event: Event }) => {
   const bgColorClass = event.color === 'violet' ? 'bg-violet' : 'bg-ink';
   const bgColorClassTransparent = event.color === 'violet' ? 'bg-violet/5' : 'bg-ink/5';
   const borderColorClass = event.color === 'violet' ? 'border-violet/25' : 'border-ink/25';
+  const linkColorClasses = event.color === 'violet'
+    ? 'text-violet border-violet/30 bg-violet/10 hover:bg-violet hover:text-white'
+    : 'text-ink border-ink/30 bg-ink/10 hover:bg-ink hover:text-white';
 
   // Base style classes
   const nodeBaseClasses = "absolute left-0 w-5 h-5 rounded-full z-20 group-hover:scale-150 transition-transform duration-300 ease-out border-2 border-cream";
@@ -58,9 +64,20 @@ const EventCard = ({ event }: { event: Event }) => {
           <h3 className={`text-xl font-heading ${colorClass}`}>{event.title}</h3>
         </div>
 
-        {/* Description - hidden until hover */}
-        <div className="h-0 group-hover:h-auto overflow-hidden transition-all duration-300 ease-out bg-white">
-          <p className="p-4 text-ink/75">{event.description}</p>
+        {/* Description */}
+        <div className="p-4 bg-white">
+          <p className="text-ink/75">{event.description}</p>
+          {event.link && (
+            <a
+              href={event.link.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`mt-3 inline-flex items-center gap-2 px-4 py-2 text-sm font-bold rounded-md border transition-all ${linkColorClasses}`}
+            >
+              {event.link.label}
+              <FaExternalLinkAlt className="text-xs" aria-hidden />
+            </a>
+          )}
         </div>
       </div>
     </div>

--- a/components/sections/Projects.tsx
+++ b/components/sections/Projects.tsx
@@ -43,7 +43,7 @@ const Projects = () => {
         </p>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-4xl mb-16">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-16">
         {projects.map((project) => (
           <ProjectCard
             key={project.name}


### PR DESCRIPTION
## Summary
- **Schedule section usability**: homepage timeline cards no longer hide their descriptions behind a hover-to-expand interaction — they render fully expanded (which also fixes touch devices, where hover barely worked), and events can carry a color-matched link button.
- **Info Night event link**: both the homepage timeline and the calendar page link Info Night to its [ExperienceWMU event page](https://experiencewmu.wmich.edu/event/12515581) via a new optional `link` field on events, rendered as an "Event Details" button that opens in a new tab.
- **Projects grid**: project cards lay out 3-wide on desktop (2-wide tablet, single column mobile), so the three active projects fill one row and future ones wrap below.
- **CLAUDE.md**: note for future sessions to check a PR's merge state before pushing follow-ups or editing it.

## Testing
- `npm run build` passes (all 11 static pages generate)
- Playwright end-to-end against the production build, all passing:
  - Timeline descriptions visible without hover; Event Details buttons href-checked on homepage and calendar
  - Projects grid renders 3 cards on one row at desktop width and stacks single-column on mobile, with AI Inference Server first

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4kgQ8QvqNASGU5PmyUZhK

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4kgQ8QvqNASGU5PmyUZhK)_