### PR TITLE
Share event data between the calendar page and landing schedule

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -2,52 +2,12 @@ import React from "react";
 import { FaExternalLinkAlt } from "react-icons/fa";
 import Header from "@/components/layout/Header";
 import Footer from "@/components/layout/Footer";
+import { EVENTS } from "@/lib/events";
 
 export const metadata = {
   title: "Calendar | Data Science & AI Club at WMU",
   description: "Upcoming events from the Data Science & AI Club at Western Michigan University",
 };
-
-type Event = {
-  id: number;
-  title: string;
-  date: string;
-  description: string;
-  color: "violet" | "ink";
-  link?: { href: string; label: string };
-};
-
-const events: Event[] = [
-  {
-    id: 1,
-    title: "Bronco Bash",
-    date: "Tue Sep 1 2026, 3:00-6:00pm | Main Campus",
-    description: "Come support us and stop by our table for free goodies and snacks!",
-    color: "violet",
-  },
-  {
-    id: 2,
-    title: "Info Night",
-    date: "Thu Sep 3 2026, 6:30-9:00pm | Parkview Campus, Room D-109",
-    description: "Kick off the year with us! Featuring speaker Jia Chen, plus introductions to Developer Club, DSAIC, and W1 Builders. Hosted in collaboration with Developer Club and W1 Builders.",
-    color: "ink",
-    link: { href: "https://experiencewmu.wmich.edu/event/12515581", label: "Event Details" },
-  },
-  {
-    id: 3,
-    title: "Company Tour",
-    date: "TBA",
-    description: "Currently in the works, stay tuned!",
-    color: "violet",
-  },
-  {
-    id: 4,
-    title: "Stryker Company Tour",
-    date: "Spring | TBA",
-    description: "Visiting Stryker to learn about their industry usage of data science and AI.",
-    color: "ink",
-  },
-];
 
 const CalendarPage = () => {
   return (
@@ -72,7 +32,7 @@ const CalendarPage = () => {
               }}></div>
 
               {/* Event Items */}
-              {events.map((event) => {
+              {EVENTS.map((event) => {
                 const colorValue = event.color === "violet" ? "#7243C1" : "#25197A";
                 const colorValueTransparent = event.color === "violet" ? "rgba(114, 67, 193, 0.06)" : "rgba(37, 25, 122, 0.05)";
                 const colorValueBorder = event.color === "violet" ? "rgba(114, 67, 193, 0.3)" : "rgba(37, 25, 122, 0.3)";

--- a/components/sections/EventsTimeline.tsx
+++ b/components/sections/EventsTimeline.tsx
@@ -1,43 +1,8 @@
-"use client";
-
 import React from 'react';
 import { FaExternalLinkAlt } from 'react-icons/fa';
+import { FEATURED_EVENTS, type ClubEvent } from '@/lib/events';
 
-type Event = {
-  id: number;
-  title: string;
-  date: string;
-  description: string;
-  color: 'violet' | 'ink';
-  link?: { href: string; label: string };
-};
-
-const events: Event[] = [
-  {
-    id: 1,
-    title: "Bronco Bash",
-    date: "Tue Sep 1 2026, 3-6pm | Main Campus",
-    description: "Come support us and stop by our table for free goodies and snacks!",
-    color: "violet",
-  },
-  {
-    id: 2,
-    title: "Info Night",
-    date: "Thu Sep 3 2026, 6:30-9pm | Parkview D-109",
-    description: "Kick off the year with us! Featuring speaker Jia Chen, plus introductions to Developer Club, DSAIC, and W1 Builders.",
-    color: "ink",
-    link: { href: "https://experiencewmu.wmich.edu/event/12515581", label: "Event Details" },
-  },
-  {
-    id: 3,
-    title: "Company Tour",
-    date: "TBA",
-    description: "Currently in the works, stay tuned!",
-    color: "violet",
-  },
-];
-
-const EventCard = ({ event }: { event: Event }) => {
+const EventCard = ({ event }: { event: ClubEvent }) => {
   const colorClass = event.color === 'violet' ? 'text-violet' : 'text-ink';
   const bgColorClass = event.color === 'violet' ? 'bg-violet' : 'bg-ink';
   const bgColorClassTransparent = event.color === 'violet' ? 'bg-violet/5' : 'bg-ink/5';
@@ -97,7 +62,7 @@ const EventsTimeline = () => {
 
           {/* Timeline Items */}
           <div className="relative z-20">
-            {events.map((event) => (
+            {FEATURED_EVENTS.map((event) => (
               <EventCard key={event.id} event={event} />
             ))}
           </div>

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,0 +1,49 @@
+// Single source of truth for club events. The calendar page shows every
+// event; the landing page Schedule section shows only the ones flagged
+// `featured`. Edit event info here and both pages stay in sync.
+export type ClubEvent = {
+  id: number;
+  title: string;
+  date: string;
+  description: string;
+  color: 'violet' | 'ink';
+  link?: { href: string; label: string };
+  /** Show this event in the landing page Schedule section. */
+  featured?: boolean;
+};
+
+export const EVENTS: ClubEvent[] = [
+  {
+    id: 1,
+    title: "Bronco Bash",
+    date: "Tue Sep 1 2026, 3:00-6:00pm | Main Campus",
+    description: "Come support us and stop by our table for free goodies and snacks!",
+    color: "violet",
+    featured: true,
+  },
+  {
+    id: 2,
+    title: "Info Night",
+    date: "Thu Sep 3 2026, 6:30-9:00pm | Parkview Campus, Room D-109",
+    description: "Kick off the year with us! Featuring speaker Jia Chen, plus introductions to Developer Club, DSAIC, and W1 Builders. Hosted in collaboration with Developer Club and W1 Builders.",
+    color: "ink",
+    link: { href: "https://experiencewmu.wmich.edu/event/12515581", label: "Event Details" },
+    featured: true,
+  },
+  {
+    id: 3,
+    title: "Company Tour",
+    date: "TBA",
+    description: "Currently in the works, stay tuned!",
+    color: "violet",
+  },
+  {
+    id: 4,
+    title: "Stryker Company Tour",
+    date: "Spring | TBA",
+    description: "Visiting Stryker to learn about their industry usage of data science and AI.",
+    color: "ink",
+  },
+];
+
+export const FEATURED_EVENTS = EVENTS.filter((event) => event.featured);


### PR DESCRIPTION
## Summary
- **Single source of truth for events**: all event info now lives in `lib/events.ts` (`EVENTS`). The calendar page renders every event; the landing Schedule section renders `FEATURED_EVENTS` — events flagged `featured: true` in the data.
- **Currently featured on the landing**: Bronco Bash and Info Night. Adding/removing an event from the landing is now a one-line `featured` flag flip in `lib/events.ts`.
- The landing section picks up the calendar's fuller copy (full times "3:00-6:00pm", "Parkview Campus, Room D-109", and Info Night's complete description), and keeps the latest details — Info Night on **Thu Sep 3** with its [ExperienceWMU Event Details link](https://experiencewmu.wmich.edu/event/12515581).
- `EventsTimeline` no longer needs `"use client"` — it renders on the server now, trimming a little client JS.

## Testing
- `npm run build` passes (all 11 static pages generate)
- Playwright against the production build, all passing:
  - Landing shows exactly Bronco Bash + Info Night, with the full shared copy and the Event Details link
  - Calendar shows all 4 events (Bronco Bash, Info Night, Company Tour, Stryker Company Tour) with the Info Night link intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4kgQ8QvqNASGU5PmyUZhK

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4kgQ8QvqNASGU5PmyUZhK)_